### PR TITLE
force node-red to install in the user dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,6 @@ RUN npm link node-red-contrib-security-nodes
 #RUN npm link node-red-contrib-agile-fiware
 
 EXPOSE 1880
+ENV NODE_RED_HOME=/opt/secure-nodered/.nodered
 
-CMD node index
+CMD mkdir -p .nodered/node_modules && node index

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,5 @@ RUN npm link node-red-contrib-security-nodes
 #RUN npm link node-red-contrib-agile-fiware
 
 EXPOSE 1880
-ENV NODE_RED_HOME=/opt/secure-nodered/.nodered
 
 CMD mkdir -p .nodered/node_modules && node index


### PR DESCRIPTION
env var forces install location (https://github.com/node-red/node-red/blob/0.16.2/red/runtime/nodes/registry/installer.js#L90)

node_modules folder is also needed, otherwise files are installed in parent.

This is just a partial solution to https://github.com/Agile-IoT/agile-nodered/issues/10. Unfortunately, node-red does not load these modules.

@craig-mulligan @nopbyte @koustabhdolui , ideas?