### PR TITLE
Feature readtemp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "node-red-contrib-agile-thingspeak"]
 	path = node-red-contrib-agile-thingspeak
 	url = https://github.com/Agile-IoT/node-red-contrib-agile-thingspeak.git
+[submodule "node-red-contrib-agile-deployer"]
+	path = node-red-contrib-agile-deployer
+	url = https://github.com/Agile-IoT/node-red-contrib-agile-deployer.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get install -y lm-sensors || echo "lm-sensors not available"
 
 RUN apt-get install sysstat
 
-COPY start.sh /opt/secure-nodered
+COPY start.sh sar.sh /opt/secure-nodered/
 
 EXPOSE 1880
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,12 @@ WORKDIR /opt/secure-nodered
 #
 RUN apt-get update && apt-get install -y libraspberrypi-bin || echo "libraspberrypi-bin not available"
 
+RUN apt-get install -y lm-sensors || echo "lm-sensors not available"
+
+RUN apt-get install sysstat
+
+COPY start.sh /opt/secure-nodered
+
 EXPOSE 1880
 
-CMD mkdir -p .nodered/node_modules && node index
+CMD ./start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ WORKDIR /opt/secure-nodered
 # Only for rpi: vcgencmd support
 # https://forums.resin.io/t/cant-run-vcgencmd/39
 #
-RUN apt-get update && apt-get install -y libraspberrypi-bin
+RUN apt-get update && apt-get install -y libraspberrypi-bin || echo "libraspberrypi-bin not available"
 
 EXPOSE 1880
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,12 @@ FROM $BASEIMAGE_DEPLOY
 COPY --from=0 /opt/secure-nodered /opt/secure-nodered
 WORKDIR /opt/secure-nodered
 
+#
+# Only for rpi: vcgencmd support
+# https://forums.resin.io/t/cant-run-vcgencmd/39
+#
+RUN apt-get update && apt-get install -y libraspberrypi-bin
+
 EXPOSE 1880
 
 CMD mkdir -p .nodered/node_modules && node index

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,10 @@ ARG THINGSPEAK=node-red-contrib-agile-thingspeak
 COPY $THINGSPEAK $THINGSPEAK
 RUN npm install $THINGSPEAK
 
+ARG DEPLOYER=node-red-contrib-agile-deployer
+COPY $DEPLOYER $DEPLOYER
+RUN npm install $DEPLOYER
+
 # adding Agile-Recommender support
 COPY node-red-contrib-agile-recommender node-red-contrib-agile-recommender
 RUN npm install node-red-contrib-agile-recommender

--- a/sar.sh
+++ b/sar.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+while /bin/true; do
+  out=$(sar 1 1)
+  echo "$out" > /var/tmp/sar
+done

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
-sar 1 > /var/tmp/sar 2>/dev/null &
+./sar.sh 2>/dev/null &
 mkdir -p .nodered/node_modules 
 node index

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+sar 1 > /var/tmp/sar 2>/dev/null &
+mkdir -p .nodered/node_modules 
+node index


### PR DESCRIPTION
Add node-red-contrib-agile-deployer to agile-nodered

The package adds 3 new nodes: tab-deploy, cloud-link and heroku-deploy. cloud-link needs some programs present to run, because it needs to get cpu values and temperature from the system. The programs are system dependent: on rpi, it gets the temperature from vcgencmd; on x64, it gets the temperature using lm-sensors. Dockerfile is updated to install the needed packages. Additionally, a sar 1 is run in the background to get the CPU usage (executed in new file start.sh). 

IMPORTANT: the following has to be added to the docker-compose file in rpi, agile-nodered container: 
```
    environment:
      - LD_LIBRARY_PATH=/opt/vc/lib
    devices:
      - /dev/vchiq:/dev/vchiq
```

Change-type: minor